### PR TITLE
Don't version copied environment.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ plugins/android.json
 plugins/ios.json
 www/
 $RECYCLE.BIN/
+src/environments/environment.json
 
 .DS_Store
 Thumbs.db


### PR DESCRIPTION
Right now the file is versioned. I think it shouldn't, because we don't want it to change at every build for dev/prod env